### PR TITLE
fix(ios): fix build error - NitroSseNetworkInspector.h not found in u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1 (2026-03-05)
+
+### Fixes
+
+*   **iOS**: Fixed a critical build error where `NitroSseNetworkInspector.h` was not found in the Umbrella Header when using modular headers (CocoaPods). Added the header to `s.source_files` in the podspec to ensure correct visibility.
+
 ## 1.4.0 (2026-03-05)
 
 ### Features

--- a/NitroSse.podspec
+++ b/NitroSse.podspec
@@ -14,9 +14,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/IAmTester35/react-native-nitro-sse.git", :tag => "#{s.version}" }
 
   s.source_files = [
-    "ios/*.{swift}",
-    "ios/*.{m,mm}",
-    "cpp/**/*.{hpp,cpp}",
+    "ios/*.{h,m,mm,swift}",
+    "cpp/**/*.{h,hpp,cpp}",
   ]
   
   s.public_header_files = [

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install react-native-nitro-sse react-native-nitro-modules
 
 | react-native-nitro-sse | react-native-nitro-modules |
 | :--------------------- | :------------------------- |
-| **1.4.0**              | **0.35.0**                 |
+| **1.4.0 - 1.4.1**      | **0.35.0**                 |
 | **1.2.2 - 1.3.1**      | **0.34.1**                 |
 | **1.2.0 - 1.2.1**      | **0.34.0**                 |
 | **1.1.0**              | **0.33.9**                 |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroSse (1.4.0):
+  - NitroSse (1.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -69,7 +69,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroSse/Tests (1.4.0):
+  - NitroSse/Tests (1.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2804,7 +2804,7 @@ SPEC CHECKSUMS:
   hermes-engine: 3deeb8b0e433cfec71fc6c1d99b1768b4efd453a
   LDSwiftEventSource: b0826ca826ca890609a9833a05cae1f357fd3b99
   NitroModules: 1dc73273d6e3aee937eec41ef3ed9470804b9884
-  NitroSse: da75d76cb013f7bbac0ab5f3dcc3f30099fec634
+  NitroSse: 62dd38a6ff92e6de562ffffeb3807153f77fc4c4
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 2b70c6e3abe00396cefd8913efbf6a2db01a2b36
   RCTRequired: f3540eee8094231581d40c5c6d41b0f170237a81

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-sse",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "High-performance Server-Sent Events (SSE) for React Native, powered by Nitro Modules.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
…mbrella header

Add .h extension to source_files in podspec so the header is correctly picked up by CocoaPods when using modular headers (RN 0.83+)