### PR TITLE
chore: remove redundant NODE_AUTH_TOKEN from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,4 @@ jobs:
           else
             npm publish --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow while preserving existing beta, alpha, and standard publishing behavior.
  * Maintained public package access and provenance settings for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->