### PR TITLE
fix(ci): checkout head branch on workflow_run event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Setup


### PR DESCRIPTION
Fix checkout ref in publish workflow when triggered by workflow_run event.