### PR TITLE
Prevents duplicate iOS reconnect loops by making Nitro SSE the sole owner of error driven reconnection decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.1 (2026-08-13)
+
+### Fixes
+
+- **iOS**: Prevented duplicate reconnect loops by making Nitro SSE the sole retry owner while forwarding LDSwiftEventSource failures through the existing reconnect strategy.
+
 ## 2.4.0 (2026-08-12)
 
 ### Features

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - NitroSse (2.4.0):
+  - NitroSse (2.4.1):
     - hermes-engine
     - LDSwiftEventSource
     - NitroModules
@@ -52,7 +52,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - NitroSse/Tests (2.4.0):
+  - NitroSse/Tests (2.4.1):
     - hermes-engine
     - LDSwiftEventSource
     - NitroModules
@@ -2107,7 +2107,7 @@ SPEC CHECKSUMS:
   hermes-engine: 576c9b40094cee47debbc36067b05270c1fe47eb
   LDSwiftEventSource: b0826ca826ca890609a9833a05cae1f357fd3b99
   NitroModules: 452230d9b63c6c3f59dd97eeaa27ec3449271d4a
-  NitroSse: a087045e15950d57da1f6a330d991f3a99f401a0
+  NitroSse: 661bb0be72e34485af6f4b0bd1696b31cdef4b8c
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702

--- a/ios/SseConnectionHandler.swift
+++ b/ios/SseConnectionHandler.swift
@@ -31,6 +31,10 @@ enum SseConnectionHandler {
         
         let handler = SseHandler(delegate: delegate, attemptVersion: attemptVersion, dispatcher: dispatcher)
         var esConfig = EventSource.Config(handler: handler, url: url)
+        esConfig.connectionErrorHandler = { [weak handler] error in
+            handler?.onError(error: error)
+            return .shutdown
+        }
         esConfig.urlSessionConfiguration = sessionConfig
         esConfig.headers = config.headers ?? [:]
         

--- a/ios/Tests/NitroSseTests.swift
+++ b/ios/Tests/NitroSseTests.swift
@@ -361,11 +361,16 @@ class NitroSseTests: XCTestCase {
     class MockSseConnectionDelegate: SseConnectionDelegate {
         var didOpen = false
         var didClose = false
+        var failureCount = 0
+        var onFailure: ((Int) -> Void)?
         func connectionDidOpen(attemptVersion: Int) { didOpen = true }
         func connectionDidClose(attemptVersion: Int) { didClose = true }
         func connectionDidReceiveMessage(eventType: String, data: String, lastEventId: String, attemptVersion: Int) {}
         func connectionDidReceiveComment(_ comment: String, attemptVersion: Int) {}
-        func connectionDidFail(error: Error, attemptVersion: Int) {}
+        func connectionDidFail(error: Error, attemptVersion: Int) {
+            failureCount += 1
+            onFailure?(failureCount)
+        }
     }
 
     func testConnectionHandlerCreation() {
@@ -405,5 +410,52 @@ class NitroSseTests: XCTestCase {
         
         XCTAssertNotNil(eventSource)
         eventSource.stop()
+    }
+
+    func testConnectionHandlerDoesNotRunIndependentReconnectLoop() {
+        let config = SseConfig(
+            url: "http://127.0.0.1:1/events",
+            method: .get,
+            headers: [:],
+            body: nil,
+            backgroundExecution: false,
+            batchingIntervalMs: 0,
+            maxBufferSize: 1000,
+            connectionTimeoutMs: 500,
+            readTimeoutMs: 500,
+            retryIntervalMs: 1000,
+            maxRetryIntervalMs: 30000,
+            jitterFactor: 0.5,
+            maxReconnectAttempts: nil,
+            autoParseJSON: false,
+            monitorNetwork: false,
+            onBeforeRequest: nil,
+            mock: nil
+        )
+        let delegate = MockSseConnectionDelegate()
+        let firstFailure = expectation(description: "Initial connection failure is forwarded")
+        let duplicateFailure = expectation(description: "LDSwiftEventSource does not reconnect independently")
+        duplicateFailure.isInverted = true
+        delegate.onFailure = { count in
+            if count == 1 {
+                firstFailure.fulfill()
+            } else {
+                duplicateFailure.fulfill()
+            }
+        }
+
+        let eventSource = SseConnectionHandler.createEventSource(
+            url: URL(string: config.url)!,
+            config: config,
+            lastProcessedId: nil,
+            delegate: delegate,
+            attemptVersion: 1,
+            dispatcher: MockSseDispatcher()
+        )
+        defer { eventSource.stop() }
+
+        wait(for: [firstFailure], timeout: 1.0)
+        wait(for: [duplicateFailure], timeout: 2.5)
+        XCTAssertEqual(delegate.failureCount, 1)
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-sse",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "High-performance Server-Sent Events (SSE) for React Native, powered by Nitro Modules.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary

We need to override LDSwiftEventSource's default reconnect logic with Nitro SSE's, otherwise both enter together into a retry loop.

`LDSwiftEventSource` automatically reconnects after most connection errors when its default `connectionErrorHandler` returns `.proceed`. That's why we need to override it.

At the same time, `SseHandler.onError` forwarded that failure to `NitroSse.connectionDidFail`, which applied NitroSSe’s own error handling code.

As a result, one network failure could activate two independent retry systems:  LDSwiftEventSource’s internal reconnect loop and Nitro SSE’s `scheduleAutomaticReconnect` path.

Applications using unlimited retries would enter an infinite loop of retries.

The PR also prepares a 2.4.1 patch release (on my fork. feel free to override those commits / versioning if needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS Server-Sent Events reconnection handling.
  * Prevented duplicate reconnect attempts after connection failures.
  * Ensured connection errors follow the existing retry strategy.

* **Release**
  * Updated the package version to 2.4.1.
  * Documented the iOS reconnection fix in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->