### PR TITLE
chore(github): allow blank issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Feature Request 💡
     url: https://github.com/IAmTester35/react-native-nitro-sse/discussions/new?category=ideas


### PR DESCRIPTION
## Description
Enables blank issue creation by setting `blank_issues_enabled: true` in `.github/ISSUE_TEMPLATE/config.yml`.

## Motivation
Previously, `blank_issues_enabled: false` blocked creating blank issues without a strict issue template, preventing users from opening general or ad-hoc issues/tickets directly.

## Changes
- Updated `.github/ISSUE_TEMPLATE/config.yml` to set `blank_issues_enabled: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled users to create blank issues without selecting a predefined template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->